### PR TITLE
Add NFTz zone

### DIFF
--- a/lib/nodes.go
+++ b/lib/nodes.go
@@ -70,4 +70,9 @@ var NODES = map[uint64]DeSoNode{
 		URL:   "https://members.giftclout.com",
 		Owner: "RajLahoti",
 	},
+	12:{
+		Name:  "NFTz",
+		URL:   "https://nftz.zone",
+		Owner: "mvanhalen",
+	}
 }


### PR DESCRIPTION
Add NFTz node. We started early October and have minting and post options. nftz.zone is our frontend. DeSo transactions are done via node.nft.zone or api.nft.zone. Updated to 12 since I saw a PR for 11.